### PR TITLE
Close button to panel  |  Clear console button | Bold style for alias task | Alias task will be shown in the top of panel | Settings for save relative path, if grantfile.js is not locate in root of the project

### DIFF
--- a/node/GruntDomain.js
+++ b/node/GruntDomain.js
@@ -56,9 +56,31 @@
 		grunt.option('gruntfile', path + "Gruntfile.js");
 		grunt.task.init([]);
 		
-	
-		var  _tasks = Object.keys(grunt.task._tasks).sort();
-		return _tasks;
+        var tasks = [];
+        for (var key in grunt.task._tasks) 
+        {
+            var task = {};
+            task.name = key;
+            task.isAlias = (grunt.task._tasks[key].info && grunt.task._tasks[key].info.indexOf("Alias for ") > -1);
+            
+            tasks.push(task);
+        }
+
+		return tasks.sort(function(a, b)
+            {
+                if((a.isAlias && b.isAlias) || (!a.isAlias && !b.isAlias)) 
+                {
+                    return a.name === b.name ? 0 : (a.name < b.name ? -1 : 1);
+                } 
+                else if(a.isAlias) 
+                {
+                    return -1;
+                } 
+                else 
+                {
+                    return 1;
+                }
+           });
     }
 	
 	

--- a/package.json
+++ b/package.json
@@ -13,5 +13,14 @@
   ],
   "engines": {
     "brackets": ">=0.32.0"
-  }
+  },
+    "repository": 
+    {
+        "type": "git",
+        "url": "https://github.com/dhategan/brackets-grunt"
+    },
+    "bugs": 
+    {
+        "url": "https://github.com/dhategan/brackets-grunt/issues"
+    }
 }

--- a/panel/panel.html
+++ b/panel/panel.html
@@ -2,9 +2,12 @@
 	<div class="toolbar simple-toolbar-layout mainToolbar">
 		<div class="btn-group">
 			<button title="Refresh" class="btn small" id="refresh">Refresh</button>
+            <button title="Clear Console" class="btn small" id="clear-console">Clear Console</button>
 		</div>
 		<div class="grunt-message grunt-loader grunt-hide">Loading...</div>
 		<div class="grunt-message grunt-runner grunt-hide"></div>
+        <input type="text" class="path" id="path" />
+        <a href="#" id="close" class="close">×</a>
 	</div>
 	
 	<div class="task-list resizable-content">

--- a/panel/task-list-template.html
+++ b/panel/task-list-template.html
@@ -1,8 +1,8 @@
 
 	<table class="task-table table table-striped table-condensed row-highlight">
 	{{#tasks}}
-		<tr class="task" task-name="{{.}}">
-			<td>{{.}}</td>
+		<tr class="task" task-name="{{name}}">
+			<td class="{{#isAlias}}task-alias{{/isAlias}}">{{name}}</td>
 		</tr>
 	{{/tasks}}
 	</table>

--- a/style/style.css
+++ b/style/style.css
@@ -54,3 +54,13 @@
 {
 		
 }
+
+.task-alias { font-weight: 800; }
+.path
+{
+    position: absolute;
+    right: 30px;
+    top: 36%;
+    margin-top: -10px;
+    width: 250px;
+}


### PR DESCRIPTION
- Added `repository` section into `package.js` file
- Added close button to panel (see right corner in the screenshot)
- Added `Clear Console` button. Clears the grunt output window.
- Alias task now has bold font style and will be located in the top.
- Added the settings for save a relative path. If `gruntfile.js` is not locate in root of the project you can enter the relative path (see textbox in the right side of the screenshot) and click in `Refresh` button to re-find the `gruntfile.js`

![brackets-grunt-1](https://cloud.githubusercontent.com/assets/946095/4645539/43d065be-546a-11e4-8ea7-6c9e9aa93049.png)
