### PR TITLE
Bug Fix: The plugin preference for amending the grunt files search path ...

### DIFF
--- a/main.js
+++ b/main.js
@@ -148,7 +148,7 @@ define(function (require, exports, module) {
 		});
 		panel.$panel.on("click", "#refresh", function () {
             path = panel.$panel.find("#path").val();
-            if (pathSettingName && path) {
+            if (pathSettingName && (path || path === '')){
                 PreferencesManager.set(pathSettingName, path);
             }
 			getTasks();


### PR DESCRIPTION
...(stored in the brackets.json as "brackets-grunt.????-path": ""), and set using the panels input box, could not be cleared with an empty string. This change allows the setting to be reset to "" empty if the input box is empty and the Refresh button is clicked on the panel.

There is no issue raised for this that I can find. Perhaps I should have raised one...